### PR TITLE
Speed up Link Validation

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -544,7 +544,7 @@ class Database(object):
 		"""
 
 		if not doctype in self.value_cache:
-			self.value_cache = self.value_cache[doctype] = {}
+			self.value_cache[doctype] = {}
 
 		if fieldname in self.value_cache[doctype]:
 			return self.value_cache[doctype][fieldname]


### PR DESCRIPTION
## Description:
db.value_cache is erased every time get_single_value is called and doctype is not found in cache.
This causes an endless loop of erasing and recreating it if two different single doctype values are requested in a transaction, which essentially make this cache useless overhead.

As a Temprorary fix, Don't erase the whole cache, just initiate new dictionary for missing doctype.